### PR TITLE
Create a .glade to fix 'rake pot'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 doc/
 .yardoc/
+*.pot

--- a/installation.SLES4HPC.glade
+++ b/installation.SLES4HPC.glade
@@ -1,0 +1,1 @@
+package/installation.xml


### PR DESCRIPTION
Add a `.glade` link in order to make `rake pot` to work properly. I am not bumping the version because this change is not included in the RPM.